### PR TITLE
Update wordpress_bruteforce.py - Fix maximum recursion depth exceeded

### DIFF
--- a/files/wordpress_bruteforce.py
+++ b/files/wordpress_bruteforce.py
@@ -12,7 +12,7 @@ from gevent.pool import Pool
 from gevent import monkey
 
 
-monkey.patch_all()
+monkey.patch_all(ssl=False)
 
 
 init(autoreset=True)


### PR DESCRIPTION

![Screenshot 2024-09-02 135529](https://github.com/user-attachments/assets/339b9a69-7718-4625-8028-f440af0a6c0b)


on https sites, monkey tries to load the ssl when it is already loaded by requests

ref: https://github.com/benoitc/gunicorn/issues/2796